### PR TITLE
fixing invalid argument check in match methods

### DIFF
--- a/jstd-adapter.js
+++ b/jstd-adapter.js
@@ -238,7 +238,7 @@ var assertString = function (message, actual) {
 };
 
 var assertMatch = function (message, regexp, actual) {
-  if (arguments.length < 2) {
+  if (arguments.length < 3) {
     actual = regexp;
     regexp = message;
   }
@@ -247,7 +247,7 @@ var assertMatch = function (message, regexp, actual) {
 };
 
 var assertNoMatch = function (message, regexp, actual) {
-  if (arguments.length < 2) {
+  if (arguments.length < 3) {
     actual = regexp;
     regexp = message;
   }


### PR DESCRIPTION
assertMatch/noMatch didn't work with just two arguments, as the check was invalid. now it works as intended and does not break existing JsTestDriver tests using these methods
