### PR TITLE
Add support for this references to the TestCase object

### DIFF
--- a/jstd-adapter.js
+++ b/jstd-adapter.js
@@ -314,16 +314,18 @@ window.__karma__.start = function () {
     // setUp and tearDown callbacks are executed as beforeEach and afterEach
     describe(testName, function () {
       beforeEach(function () {
-        setUp.call(this);
+        setUp.call(prototype);
       });
       afterEach(function () {
-        tearDown.call(this);
+        tearDown.call(prototype);
         // Clean document.body content.
         document.body.innerHTML = '';
       });
       specNames.forEach(function (specName) {
         if (specName.indexOf('test') === 0) {
-          it(specName.replace(/^test/, 'should '), prototype[specName]);
+          it(specName.replace(/^test/, 'should '), function () {
+            prototype[specName]();
+          });
         }
       });
     })

--- a/test.js
+++ b/test.js
@@ -32,6 +32,34 @@ TestCase("OtherTest", {
     }
 });
 
+(function () {
+    var testCaseRef = {
+        sHello: null,
+        helperMethod: function () {
+          return true;
+        },
+        setUp: function(){
+            assertSame("this in setUp should refernce the TestCase object", testCaseRef, this);
+            this.sHello = "Hello World!";
+        },
+        tearDown: function(){
+            assertSame("this in tearDown should reference the TestCase object", testCaseRef, this);
+            this.sHello = null;
+        },
+        "test reference TestCase object": function () {
+            assertSame("this in test should reference the TestCase object", testCaseRef, this);
+        },
+        "test have value from setUp": function() {
+            assertEquals("Hello World!", this.sHello);
+        },
+        "test allow helper methods": function () {
+            assertTrue(this.helperMethod());
+        }
+    };
+
+    TestCase("ThisReferences", testCaseRef);
+})();
+
 describe('jasmine spec', function() {
   it('should work', function() {
     expect(true).toBe(true);


### PR DESCRIPTION
JsTestDriver allows you to add properties and helper methods on the TestCase object. It's probably better to have an IIFE around each TestCase to create a local scope, but we have quite a few legacy tests that reference `this` and expect it to be the TestCase object.
