### PR TITLE
Return a reference to the injected html

### DIFF
--- a/jstd-adapter.js
+++ b/jstd-adapter.js
@@ -47,7 +47,7 @@ var injectHTML = function (sHTML) {
 
   var content = docFrag.childNodes.length > 1 ? docFrag : docFrag.firstChild;
 
-  document.body.appendChild(content);
+  return document.body.appendChild(content);
 };
 
 // matchers


### PR DESCRIPTION
In JsTestDriver you could get a reference to the injected html, so you don't need to search for the element in the document:

```
/*:DOC foo = <div><p>foo</p></div>*/
assertNotUndefined(this.foo);
```

With injectHtml:

```
var foo = injectHTML("<div><p>foo</p></div>");
assertNotUndefined(foo);
```
